### PR TITLE
Fixed issue in binary object transmission causing empty packages.

### DIFF
--- a/client.js
+++ b/client.js
@@ -46,7 +46,7 @@ exports.mesh = function(mesh, cbMesh) {
       pipe.path = path;
 
       ws.onmessage = function(e) {
-        var packet = lob.decode(e.data);
+        var packet = lob.decode(new Buffer(e.data,'binary'));
         if (!packet) {
           var hex = e.data.toString("hex");
           log.error(LOGNAME, "dropping invalid packet from", id, hex);
@@ -65,9 +65,9 @@ exports.mesh = function(mesh, cbMesh) {
         if (!ws) return;  // Disconnected
         var buf = lob.encode(packet);
         if (isNode) {
-          ws.send(buf, cbSend);
+          ws.send(buf.toString('binary'), cbSend);
         } else {
-          ws.send(buf);
+          ws.send(buf.toString('binary'));
           cbSend();
         }
       };

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ exports.mesh = function(mesh, cbMesh) {
     log.info(LOGNAME, "got connection from", id);
 
     ws.onmessage = function(e) {
-      var packet = lob.decode(e.data);
+      var packet = lob.decode(new Buffer(e.data,'binary'));
       if (!packet) {
         var hex = e.data.toString("hex");
         log.warn(LOGNAME, "dropping invalid packet from", id, hex);
@@ -55,7 +55,7 @@ exports.mesh = function(mesh, cbMesh) {
     pipe.onSend = function(packet, link, cbSend) {
       if (!ws) return;  // Disconnected
       var buf = lob.encode(packet);
-      ws.send(buf, cbSend);
+      ws.send(buf.toString('binary'), cbSend);
     };
   });
 


### PR DESCRIPTION
The combination of telehash-ws with the latest version of telehash-js ended in the transmission of empty packages and caused unhandled exceptions. This issue can easily be fixed by converting the buffer to a string before sending it. It is done the same way in telehash-http, which means that the fix is more or less aligned with the official example.
